### PR TITLE
Fixing mixed content warning

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     <!-- Google Fonts -->
     <link href="https://fonts.googleapis.com/css?family=Raleway" rel="stylesheet">
     <!-- Ionicons -->
-    <link rel="stylesheet" type="text/css" href="http://code.ionicframework.com/ionicons/2.0.1/css/ionicons.min.css">
+    <link rel="stylesheet" type="text/css" href="https://code.ionicframework.com/ionicons/2.0.1/css/ionicons.min.css">
   </head>
 
   <body>


### PR DESCRIPTION
There is a mixed content warning on the page.

The icon pack was being loaded over HTTP while the page itself was HTTPS. This fixes a bug where the icons do not work.